### PR TITLE
adding a context_id to get_contexts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,9 @@ Package: childesr
 Type: Package
 Title: Accessing the 'CHILDES' Database
 Description: Tools for connecting to 'CHILDES', an open repository for
-    transcripts of parent-child interaction. For more information on the 
+    transcripts of parent-child interaction. For more information on the
     underlying data, see <https://childes-db.stanford.edu>.
-Version: 0.2.2
+Version: 0.2.3
 Authors@R: c(
     person("Mika", "Braginsky", email = "mika.br@gmail.com", role = c("aut", "cre")),
     person("Alessandro", "Sanchez", email = "amsan7@gmail.com", role = c("aut", "ctb")),
@@ -31,5 +31,5 @@ Suggests:
     knitr,
     rmarkdown,
     curl
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr

--- a/R/childesr.R
+++ b/R/childesr.R
@@ -725,7 +725,7 @@ get_contexts <- function(collection = NULL, language = NULL, corpus = NULL,
       dplyr::filter(transcript_id == tid, utterance_order >= start,
                     utterance_order <= end) %>%
       dplyr::collect()
-  })
+  }, .id = "context_id")
 
   if (remove_duplicates) {
     contexts %<>% dplyr::distinct(transcript_id, utterance_id, .keep_all = TRUE)


### PR DESCRIPTION
In get_contexts, it wasn't clear which set of n sentences should go together as a unit. I added a context_id variable that distinguishes them.